### PR TITLE
Convert to unicode to be compatible in Python3

### DIFF
--- a/ldaptor/entryhelpers.py
+++ b/ldaptor/entryhelpers.py
@@ -1,3 +1,8 @@
+
+from __future__ import unicode_literals
+
+from ldaptor._encoder import to_unicode
+
 from twisted.internet import defer
 from ldaptor import delta, ldapfilter
 from ldaptor._encoder import get_strings
@@ -179,7 +184,7 @@ class MatchMixin(object):
                 possibleMatches = [
                     x[:-len(filter.substrings[0].value)]
                     for x in possibleMatches
-                    if x.lower().endswith(filter.substrings[-1].value.lower())
+                    if x.lower().endswith(to_unicode(filter.substrings[-1].value.lower()))
                     ]
                 del substrings[-1]
 
@@ -199,14 +204,14 @@ class MatchMixin(object):
             if filter.attributeDesc.value not in self:
                 return False
             for value in self[filter.attributeDesc.value]:
-                if value  >= filter.assertionValue.value:
+                if value  >= to_unicode(filter.assertionValue.value):
                     return True
             return False
         elif isinstance(filter, pureldap.LDAPFilter_lessOrEqual):
             if filter.attributeDesc.value not in self:
                 return False
             for value in self[filter.attributeDesc.value]:
-                if value <= filter.assertionValue.value:
+                if value <= to_unicode(filter.assertionValue.value):
                     return True
             return False
         elif isinstance(filter, pureldap.LDAPFilter_and):

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -15,6 +15,8 @@
 
 """LDAP protocol message conversion; no application logic here."""
 
+from __future__ import unicode_literals
+
 import string
 
 import six
@@ -511,13 +513,13 @@ class LDAPFilter_substrings_any(LDAPString):
     tag = CLASS_CONTEXT | 0x01
 
     def asText(self):
-        return self.escaper(self.value)
+        return self.escaper(to_unicode(self.value))
 
 class LDAPFilter_substrings_final(LDAPString):
     tag = CLASS_CONTEXT | 0x02
 
     def asText(self):
-        return self.escaper(self.value)
+        return self.escaper(to_unicode(self.value))
 
 class LDAPBERDecoderContext_Filter_substrings(BERDecoderContext):
     Identities = {
@@ -588,23 +590,23 @@ class LDAPFilter_substrings(BERSequence):
         if final is None:
             final = ''
 
-        return '(' + self.type + '=' \
-               + '*'.join([initial] + any + [final]) + ')'
+        return '(' + to_unicode(self.type) + '=' \
+               + to_unicode('*'.join([initial] + any + [final])) + ')'
 
 
 class LDAPFilter_greaterOrEqual(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x05
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '>=' + \
-               self.escaper(self.assertionValue.value) + ')'
+        return '(' + to_unicode(self.attributeDesc.value) + '>=' + \
+               self.escaper(to_unicode(self.assertionValue.value)) + ')'
 
 class LDAPFilter_lessOrEqual(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x06
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '<=' + \
-               self.escaper(self.assertionValue.value) + ')'
+        return '(' + to_unicode(self.attributeDesc.value) + '<=' + \
+               self.escaper(to_unicode(self.assertionValue.value)) + ')'
 
 class LDAPFilter_present(LDAPAttributeDescription):
     tag = CLASS_CONTEXT | 0x07
@@ -617,8 +619,8 @@ class LDAPFilter_approxMatch(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x08
 
     def asText(self):
-        return '(' + self.attributeDesc.value + '~=' + \
-               self.escaper(self.assertionValue.value) + ')'
+        return '(' + to_unicode(self.attributeDesc.value) + '~=' + \
+               self.escaper(to_unicode(self.assertionValue.value)) + ')'
 
 
 class LDAPMatchingRuleId(LDAPString):
@@ -741,11 +743,11 @@ class LDAPFilter_extensibleMatch(LDAPMatchingRuleAssertion):
 
     def asText(self):
         return '(' + \
-               (self.type.value if self.type else '') + \
+               (to_unicode(self.type.value) if self.type else '') + \
                (':dn' if self.dnAttributes and self.dnAttributes.value else '') + \
-               ((':' + self.matchingRule.value) if self.matchingRule else '') + \
+               ((':' + to_unicode(self.matchingRule.value)) if self.matchingRule else '') + \
                ':=' + \
-               self.escaper(self.matchValue.value) + \
+               self.escaper(to_unicode(self.matchValue.value)) + \
                ')'
 
 class LDAPBERDecoderContext_Filter(BERDecoderContext):

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -19,6 +19,8 @@ import string
 
 import six
 
+from ldaptor._encoder import to_unicode
+
 from ldaptor.protocols.pureber import (
 
     BERBoolean, BERDecoderContext, BEREnumerated, BERInteger, BERNull,
@@ -495,8 +497,8 @@ class LDAPFilter_equalityMatch(LDAPAttributeValueAssertion):
     tag = CLASS_CONTEXT | 0x03
 
     def asText(self):
-        return '('+self.attributeDesc.value+'=' \
-               +self.escaper(self.assertionValue.value)+')'
+        return '('+(to_unicode(self.attributeDesc.value)+'=' \
+               +self.escaper(to_unicode(self.assertionValue.value)))+')'
 
 class LDAPFilter_substrings_initial(LDAPString):
     tag = CLASS_CONTEXT | 0x00


### PR DESCRIPTION
Python3 compatibility fix for string type.

All the following searches have been verified in both Py2 and Py3 to make sure, there are no tracebacks

```
1. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(cn=Kumar Udaya)"
2. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(mail=*aren)"
3. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(groupType:1.2.840.113556.1.4.803:=21474836)"
4. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(uid=5)"
5. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(uid<=5)"
6. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(uid>=5)"
7. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(cn=*)"
8. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(cn~=Kumar Udaya)"
9. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(&(cn=Kumar Udaya)(uid<=5))"
10. ldapsearch -H ldap://localhost:10389 -b dc=foxpass,dc=com -D cn=test-binder-1,dc=foxpass,dc=com -w cGTDt2lwqEwy2tsz "(|(cn=Kumar Udaya)(uid<=5))"
```