### PR TITLE
Fix integer attribute value LDIF representation under Python 3

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -33,6 +33,8 @@ Bugfixes
   `LDAPResult(resultCode=0, matchedDN='uid=user')` instead of `LDAPResult(resultCode=0, matchedDN="b'uid=user'")`.
 - ``ldaptor.protocols.pureldap.LDAPMatchingRuleAssertion`` initialization for Python 3 was failed for bytes arguments.
 - ``ldaptor.protocols.pureldap.LDAPExtendedResponse`` custom tag parameter was not used.
+- ``ldaptor._encoder.to_bytes()`` was fixed under Python 3 to return integers as their numeric
+  representation rather than a sequence of null bytes.
 
 Release 19.0 (2019-03-05)
 -------------------------

--- a/ldaptor/_encoder.py
+++ b/ldaptor/_encoder.py
@@ -17,6 +17,8 @@ def to_bytes(value):
     """
     if hasattr(value, 'toWire'):
         return value.toWire()
+    if isinstance(value, six.integer_types):
+        return str(value).encode("utf-8")
     if isinstance(value, six.text_type):
         return value.encode('utf-8')
     return bytes(value)

--- a/ldaptor/test/test_encoder.py
+++ b/ldaptor/test/test_encoder.py
@@ -53,6 +53,14 @@ class EncoderTests(unittest.TestCase):
         obj = b'bytes'
         self.assertEqual(ldaptor._encoder.to_bytes(obj), b'bytes')
 
+    def test_int_object(self):
+        """
+        integer is converted to a string representation, then encoded to bytes
+        if passed to to_bytes function
+        """
+        obj = 42
+        self.assertEqual(ldaptor._encoder.to_bytes(obj), b'42')
+
 
 class WireStrAliasTests(unittest.TestCase):
 


### PR DESCRIPTION
Using ldaptor under Python 3, integer attribute values are converted to broken LDIF representations, due to a change in how the `bytes()` constructor works in Python 3.

Code example to reproduce the issue:

```python
from ldaptor.inmemory import ReadOnlyInMemoryLDAPEntry
entry = ReadOnlyInMemoryLDAPEntry(
    dn="uid=ryan,ou=people,dc=ryanpark,dc=org",
    attributes={"age": [40]}
)
print(entry.toWire().decode("utf-8"))
```

Output in Python 2.7.16 (working as expected):
```
dn: uid=ryan,ou=people,dc=ryanpark,dc=org
age: 40
```

Output in Python 3.7.4 (unexepcted/broken):
```
dn: uid=ryan,ou=people,dc=ryanpark,dc=org
age:: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
```

A more pathological example: Some of our users have an attribute like `sambaPwdLastSet: 1566942748` (Unix timestamp). This caused `entry.toWire()` to build a 1.5 GB payload. :sob:

This is because the behavior of the `bytes()` built-in changed from Python 2 to Python3. Previously `bytes()` was just an alias for `str()`, so `bytes(5) == str(5) == "5"`. But in Python 3, `bytes()` is more of alias for [an immutable version of] `bytearray()`, so `bytes(5) == bytearray(5) == b"\0\0\0\0\0"`.

This PR modifies `ldaptor._encoder.to_bytes()` to handle this situation correctly. This could be a pretty significant change to the LDIF output under certain workloads, but I can't imagine anyone actually intends for it to behave this way -- especially since it worked differently in Python 2.

To test the fix, you can run the code example above in `ipython`, or run the automated tests with these commands:

```
tox -e py27-test-dev ldaptor.test.test_encoder
tox -e py37-test-dev ldaptor.test.test_encoder
```

### Contributor Checklist:

* [x]  I have updated the release notes at `docs/source/NEWS.rst`
* [x]  I have updated the automated tests.
* [x]  All tests pass on your local dev environment. See `CONTRIBUTING.rst`.
